### PR TITLE
Fix: Allow local Django server to run without fullstack Docker (MongoDB replica set config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,5 @@ cython_debug/
 
 .ruff_cache
 mongo_data
+mongo_logs
 logs

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 1. Install pyenv
     - For Mac/Linux - https://github.com/pyenv/pyenv?tab=readme-ov-file#installation
     - For Windows - https://github.com/pyenv-win/pyenv-win/blob/master/docs/installation.md#chocolatey
-2. Install the configured python version (3.12.7) using pyenv by running the command
+2. Install the configured python version (3.11.5) using pyenv by running the command
     - For Mac/Linux
         ```
         pyenv install
@@ -38,9 +38,10 @@
     ```
 6. Create a `.env` file in the root directory, and copy the content from the `.env.example` file to it
 7. Install [docker](https://docs.docker.com/get-docker/) and [docker compose](https://docs.docker.com/compose/install/)
-8. Start MongoDB using docker
+8. Set up MongoDB with replica set support using the provided script:
     ```
-    docker-compose up -d db
+    chmod +x dev-setup.sh
+    ./dev-setup.sh
     ```
 9. Start the development server by running the command
     ```
@@ -71,6 +72,32 @@
     }
     ```
 4. On making changes to code and saving, live reload will work in this case as well
+
+## Daily development workflow
+After the initial setup, for daily development you only need to:
+
+1. Make sure MongoDB is running (if it's not already):
+   ```
+   docker-compose up -d db
+   ```
+
+2. Start the Django development server:
+   ```
+   python manage.py runserver
+   ```
+
+## After running docker-compose down
+If you've run `docker-compose down` and need to restart your development environment:
+
+1. Run the setup script to reinitialize MongoDB with replica set:
+   ```
+   ./dev-setup.sh
+   ```
+
+2. Start your Django application:
+   ```
+   python manage.py runserver
+   ```
 
 ## Command reference
 1. To run the tests, run the following command

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# Colors for better readability
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}=== Todo App Development Environment Setup ===${NC}"
+
+# Create required directories
+echo -e "${YELLOW}Creating directories for MongoDB data and logs...${NC}"
+mkdir -p mongo_data
+mkdir -p mongo_logs
+
+# Stop any existing containers
+echo -e "${YELLOW}Stopping any existing containers...${NC}"
+docker-compose down
+
+# Start MongoDB
+echo -e "${YELLOW}Starting MongoDB container...${NC}"
+docker-compose up -d db
+
+# Wait for MongoDB to be ready
+echo -e "${YELLOW}Waiting for MongoDB to initialize (this may take a moment)...${NC}"
+for i in {1..30}; do
+    if docker exec todo-mongo mongosh --quiet --eval "db.runCommand({ping:1}).ok" &>/dev/null; then
+        echo -e "\n${GREEN}MongoDB is up and running!${NC}"
+        break
+    fi
+    
+    if [ $i -eq 30 ]; then
+        echo -e "\n${RED}Timed out waiting for MongoDB to start. Check the logs:${NC}"
+        docker logs todo-mongo
+        exit 1
+    fi
+    
+    echo -n "."
+    sleep 2
+done
+
+# Initialize replica set
+echo -e "${YELLOW}Initializing replica set...${NC}"
+docker exec todo-mongo mongosh --eval '
+  try {
+    rs.status();
+    print("Replica set already initialized");
+  } catch (err) {
+    if (err.codeName === "NotYetInitialized") {
+      rs.initiate({
+        _id: "rs0", 
+        members: [
+          { _id: 0, host: "localhost:27017" }
+        ]
+      });
+      print("Initialized replica set");
+    } else {
+      print("Error checking replica set status: " + err);
+      quit(1);
+    }
+  }
+' || {
+    echo -e "${RED}Failed to initialize replica set.${NC}"
+    echo -e "${YELLOW}Checking MongoDB logs:${NC}"
+    docker logs todo-mongo
+    exit 1
+}
+
+# Wait for replica set to initialize
+echo -e "${YELLOW}Waiting for replica set to initialize...${NC}"
+for i in {1..15}; do
+    RS_STATUS=$(docker exec todo-mongo mongosh --quiet --eval "try { rs.status().ok } catch(e) { 0 }")
+    if [ "$RS_STATUS" == "1" ]; then
+        echo -e "${GREEN}Replica set initialized successfully!${NC}"
+        break
+    fi
+    
+    if [ $i -eq 15 ]; then
+        echo -e "${RED}Timed out waiting for replica set to initialize.${NC}"
+        echo -e "${YELLOW}You may need to check the MongoDB logs: docker logs todo-mongo${NC}"
+        exit 1
+    fi
+    
+    echo -n "."
+    sleep 2
+done
+
+# Update .env file
+ENV_FILE=".env"
+if [ -f "$ENV_FILE" ]; then
+    echo -e "${YELLOW}Updating .env file with replica set configuration...${NC}"
+    
+    # Create a temporary file
+    TEMP_FILE=$(mktemp)
+    
+    # Copy all lines except MONGODB_URI
+    grep -v "MONGODB_URI=" "$ENV_FILE" > "$TEMP_FILE" || true
+    
+    # Add the updated MONGODB_URI
+    echo "MONGODB_URI=mongodb://localhost:27017/?replicaSet=rs0" >> "$TEMP_FILE"
+    
+    # Replace the original file
+    mv "$TEMP_FILE" "$ENV_FILE"
+    
+    echo -e "${GREEN}Updated MONGODB_URI in .env file.${NC}"
+else
+    echo -e "${YELLOW}Creating new .env file with development settings...${NC}"
+    cat > "$ENV_FILE" << EOL
+ENV=DEVELOPMENT
+SECRET_KEY=unique-secret
+ALLOWED_HOSTS=localhost,127.0.0.1
+MONGODB_URI=mongodb://localhost:27017/?replicaSet=rs0
+DB_NAME=todo-app
+EOL
+    echo -e "${GREEN}Created new .env file with development settings.${NC}"
+fi
+
+echo -e "${GREEN}=== Environment setup complete! ===${NC}"
+echo -e "${YELLOW}Your .env file has been updated with the replica set configuration.${NC}"
+echo -e "${YELLOW}To start your Django app, run:${NC}"
+echo -e "${GREEN}python manage.py runserver${NC}"
+echo -e "\n${YELLOW}Note: You only need to run this setup script once or if you reset your MongoDB container.${NC}"
+echo -e "${YELLOW}For daily development, just ensure the MongoDB container is running with:${NC}"
+echo -e "${GREEN}docker-compose up -d db${NC}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: todo-django-app
     command: python manage.py runserver 0.0.0.0:8000
     environment:
-      MONGODB_URI: mongodb://db:27017
+      MONGODB_URI: mongodb://db:27017/?replicaSet=rs0
       DB_NAME: todo-app
     volumes:
       - .:/app
@@ -22,18 +22,12 @@ services:
       - "27017:27017"
     volumes:
       - ./mongo_data:/data/db
+      - ./mongo_logs:/var/log/mongodb
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "'db.runCommand({ping:1})'"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 15s
-
-    #to enable replica set, requirement for enabling transactions
-    command: >
-      sh -c "
-        mongod --replSet rs0 --bind_ip_all --logpath /var/log/mongodb.log --logappend &
-        sleep 5 &&
-        mongosh --eval 'try { rs.initiate() } catch(e) { print(e) }' &&
-        tail -f /var/log/mongodb.log
-      "
+    # Modified command to use the mounted log directory
+    command: mongod --replSet rs0 --bind_ip_all --logpath /var/log/mongodb/mongodb.log --logappend

--- a/todo_project/settings/base.py
+++ b/todo_project/settings/base.py
@@ -15,10 +15,17 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-MONGODB_URI = os.getenv("MONGODB_URI")
-DB_NAME = os.getenv("DB_NAME")
-# Application definition
+# MongoDB Connection Settings
+mongodb_uri = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
 
+if "replicaSet" not in mongodb_uri:
+    MONGODB_URI = f"{mongodb_uri}/?replicaSet=rs0"
+else:
+    MONGODB_URI = mongodb_uri
+
+DB_NAME = os.getenv("DB_NAME", "todo-app")
+
+# Application definition
 INSTALLED_APPS = [
     "rest_framework",
     "todo",


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 16-May-2025
<!--Developer Name Here-->
Developer Name: @VaibhavSingh8 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #31 

## Description

<!--Description of the changes made in this PR-->
This PR fixes the issue where the local Django server (python manage.py runserver) failed to connect to MongoDB unless the fullstack Docker environment was running. The root cause was related to MongoDB's replica set configuration, which wasn’t properly initialized when only the db service was started.

Changes Made:

✅ Added dev-setup.sh to streamline local development setup (e.g., initializing replica set).

✅ Modified docker-compose.yml to support standalone DB usage with replica set config.

✅ Updated Django settings.py to gracefully handle db connection.

✅ Updated README.md with clear instructions for local development.

### Documentation Updated?

- [x] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

![Screenshot 2025-05-16 at 3 21 07 AM](https://github.com/user-attachments/assets/8ddbb984-36a9-49b6-964e-7890fcf387ac)

![Screenshot 2025-05-16 at 3 21 39 AM](https://github.com/user-attachments/assets/17ad84dc-751a-4479-a452-694b3ffd941d)

</details>

<!--Attach or link to relevant screenshots or visual aids-->
