### PR TITLE
feat:Implements the GET `/tasks/{task_id}` endpoint to retrieve details of a specific task.

### DIFF
--- a/todo/constants/messages.py
+++ b/todo/constants/messages.py
@@ -1,11 +1,13 @@
 # Application Messages
 class AppMessages:
     TASK_CREATED = "Task created successfully"
-    
+
+
 # Repository error messages
 class RepositoryErrors:
     TASK_CREATION_FAILED = "Failed to create task: {0}"
     DB_INIT_FAILED = "Failed to initialize database: {0}"
+
 
 # API error messages
 class ApiErrors:
@@ -18,6 +20,11 @@ class ApiErrors:
     INVALID_LABEL_IDS = "Invalid Label IDs"
     PAGE_NOT_FOUND = "Requested page exceeds available results"
     UNEXPECTED_ERROR_OCCURRED = "An unexpected error occurred"
+    TASK_NOT_FOUND = "Task with ID {0} not found."
+    TASK_NOT_FOUND_TITLE = "Task Not Found"
+    INVALID_TASK_ID_FORMAT = "Invalid Task ID Format"
+    INVALID_TASK_ID_FORMAT_DETAIL = "Task ID is not in a valid format."
+
 
 # Validation error messages
 class ValidationErrors:

--- a/todo/dto/responses/create_task_response.py
+++ b/todo/dto/responses/create_task_response.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 from todo.dto.task_dto import TaskDTO
 from todo.constants.messages import AppMessages
 
+
 class CreateTaskResponse(BaseModel):
     statusCode: int = 201
     successMessage: str = AppMessages.TASK_CREATED

--- a/todo/dto/responses/error_response.py
+++ b/todo/dto/responses/error_response.py
@@ -7,6 +7,7 @@ class ApiErrorSource(Enum):
     PARAMETER = "parameter"
     POINTER = "pointer"
     HEADER = "header"
+    PATH = "path"
 
 
 class ApiErrorDetail(BaseModel):

--- a/todo/dto/responses/get_task_by_id_response.py
+++ b/todo/dto/responses/get_task_by_id_response.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+from todo.dto.task_dto import TaskDTO
+
+
+class GetTaskByIdResponse(BaseModel):
+    data: TaskDTO

--- a/todo/exceptions/task_exceptions.py
+++ b/todo/exceptions/task_exceptions.py
@@ -1,0 +1,2 @@
+class TaskNotFoundException(Exception):
+    pass

--- a/todo/repositories/task_repository.py
+++ b/todo/repositories/task_repository.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from typing import List
+from bson import ObjectId
 
 from todo.models.task import TaskModel
 from todo.repositories.common.mongo_repository import MongoRepository
@@ -73,3 +74,20 @@ class TaskRepository(MongoRepository):
 
             except Exception as e:
                 raise ValueError(RepositoryErrors.TASK_CREATION_FAILED.format(str(e)))
+
+    @classmethod
+    def get_by_id(cls, task_id: str) -> TaskModel | None:
+        """
+        Get a task by its ID from the repository.
+
+        Args:
+            task_id (str): The ID of the task to retrieve.
+
+        Returns:
+            TaskModel | None: The task model if found, otherwise None.
+        """
+        tasks_collection = cls.get_collection()
+        task_data = tasks_collection.find_one({"_id": ObjectId(task_id)})
+        if task_data:
+            return TaskModel(**task_data)
+        return None

--- a/todo/tests/integration/test_task_detail_api.py
+++ b/todo/tests/integration/test_task_detail_api.py
@@ -1,0 +1,89 @@
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.urls import reverse
+from bson import ObjectId
+from unittest.mock import patch
+from datetime import datetime
+
+from todo.exceptions.task_exceptions import TaskNotFoundException
+from todo.constants.task import TaskPriority, TaskStatus
+from todo.dto.user_dto import UserDTO
+from todo.dto.task_dto import TaskDTO
+
+
+class TaskDetailAPIIntegrationTest(APITestCase):
+    def setUp(self):
+        pass
+
+    @patch("todo.services.task_service.TaskService.get_task_by_id")
+    def test_get_task_by_id_success(self, mock_get_task_by_id):
+        task_id_str = str(ObjectId())
+        created_by_user_id = str(ObjectId())
+
+        task_dto_data = {
+            "id": task_id_str,
+            "displayId": "#123",
+            "title": "Mocked Task Title",
+            "description": "Mocked task description",
+            "priority": TaskPriority.MEDIUM,
+            "status": TaskStatus.IN_PROGRESS,
+            "assignee": None,
+            "createdBy": UserDTO(id=created_by_user_id, name="Creator User"),
+            "labels": [],
+            "startedAt": None,
+            "dueAt": datetime.fromisoformat("2024-01-01T10:00:00+00:00"),
+            "createdAt": datetime.fromisoformat("2024-01-01T09:00:00+00:00"),
+            "updatedAt": None,
+            "isAcknowledged": False,
+        }
+
+        mock_service_return_value = TaskDTO(**task_dto_data)
+        mock_get_task_by_id.return_value = mock_service_return_value
+
+        url = reverse("task_detail", args=[task_id_str])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_data_outer = response.data
+
+        response_data_inner = response_data_outer.get("data")
+        self.assertIsNotNone(response_data_inner)
+        self.assertEqual(response_data_inner["id"], task_id_str)
+        self.assertEqual(response_data_inner["title"], task_dto_data["title"])
+
+        self.assertEqual(response_data_inner["priority"], TaskPriority.MEDIUM.name)
+        self.assertEqual(response_data_inner["status"], TaskStatus.IN_PROGRESS.value)
+        self.assertEqual(response_data_inner["displayId"], task_dto_data["displayId"])
+        self.assertEqual(response_data_inner["createdBy"]["id"], created_by_user_id)
+        self.assertEqual(response_data_inner["createdBy"]["name"], "Creator User")
+
+        mock_get_task_by_id.assert_called_once_with(task_id_str)
+
+    @patch("todo.services.task_service.TaskService.get_task_by_id")
+    def test_get_task_by_id_not_found(self, mock_get_task_by_id):
+        non_existent_id = str(ObjectId())
+        mock_get_task_by_id.side_effect = TaskNotFoundException("Task not found")
+
+        url = reverse("task_detail", args=[non_existent_id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        error_detail = response.data.get("errors", [{}])[0].get("detail")
+        self.assertEqual(error_detail, "Task not found")
+        mock_get_task_by_id.assert_called_once_with(non_existent_id)
+
+    @patch("todo.services.task_service.TaskService.get_task_by_id")
+    def test_get_task_by_id_invalid_format(self, mock_get_task_by_id):
+        invalid_id = "this-is-not-an-object-id"
+        mock_get_task_by_id.side_effect = ValueError("Invalid ObjectId format")
+
+        url = reverse("task_detail", args=[invalid_id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error_detail = response.data.get("errors", [{}])[0].get("detail")
+        self.assertEqual(error_detail, "Invalid ObjectId format")
+
+        mock_get_task_by_id.assert_called_once_with(invalid_id)

--- a/todo/tests/unit/views/test_task.py
+++ b/todo/tests/unit/views/test_task.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, Mock
 from rest_framework.response import Response
 from django.conf import settings
 from datetime import datetime, timedelta, timezone
+from bson.objectid import ObjectId
 
 from todo.views.task import TaskView
 from todo.dto.user_dto import UserDTO
@@ -14,6 +15,9 @@ from todo.dto.responses.get_tasks_response import GetTasksResponse
 from todo.dto.responses.create_task_response import CreateTaskResponse
 from todo.tests.fixtures.task import task_dtos
 from todo.constants.task import TaskPriority, TaskStatus
+from todo.dto.responses.get_task_by_id_response import GetTaskByIdResponse
+from todo.exceptions.task_exceptions import TaskNotFoundException
+from todo.constants.messages import ApiErrors
 
 
 class TaskViewTests(APISimpleTestCase):
@@ -67,6 +71,66 @@ class TaskViewTests(APISimpleTestCase):
         for actual_error, expected_error in zip(response_data["errors"], expected_response["errors"]):
             self.assertEqual(actual_error["source"]["parameter"], expected_error["source"]["parameter"])
             self.assertEqual(actual_error["detail"], expected_error["detail"])
+
+    @patch("todo.services.task_service.TaskService.get_task_by_id")
+    def test_get_single_task_success(self, mock_get_task_by_id: Mock):
+        valid_task_id = str(ObjectId())
+        mock_task_data = task_dtos[0]
+        mock_get_task_by_id.return_value = mock_task_data
+
+        expected_response_obj = GetTaskByIdResponse(data=mock_task_data)
+
+        response = self.client.get(reverse("task_detail", args=[valid_task_id]))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, expected_response_obj.model_dump(mode="json"))
+        mock_get_task_by_id.assert_called_once_with(valid_task_id)
+
+    @patch("todo.services.task_service.TaskService.get_task_by_id")
+    def test_get_single_task_not_found(self, mock_get_task_by_id: Mock):
+        non_existent_task_id = str(ObjectId())
+        error_message = ApiErrors.TASK_NOT_FOUND.format(non_existent_task_id)
+        mock_get_task_by_id.side_effect = TaskNotFoundException(error_message)
+
+        response = self.client.get(reverse("task_detail", args=[non_existent_task_id]))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["statusCode"], status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["message"], ApiErrors.TASK_NOT_FOUND_TITLE)
+        self.assertEqual(len(response.data["errors"]), 1)
+        self.assertEqual(response.data["errors"][0]["source"], {"path": "task_id"})
+        self.assertEqual(response.data["errors"][0]["title"], ApiErrors.TASK_NOT_FOUND_TITLE)
+        self.assertEqual(response.data["errors"][0]["detail"], error_message)
+        mock_get_task_by_id.assert_called_once_with(non_existent_task_id)
+
+    @patch("todo.services.task_service.TaskService.get_task_by_id")
+    def test_get_single_task_invalid_id_format(self, mock_get_task_by_id: Mock):
+        invalid_task_id = "invalid-id-string"
+        mock_get_task_by_id.side_effect = ValueError(ApiErrors.INVALID_TASK_ID_FORMAT_DETAIL)
+
+        response = self.client.get(reverse("task_detail", args=[invalid_task_id]))
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["statusCode"], status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["message"], ApiErrors.INVALID_TASK_ID_FORMAT)
+        self.assertEqual(len(response.data["errors"]), 1)
+        self.assertEqual(response.data["errors"][0]["source"], {"path": "task_id"})
+        self.assertEqual(response.data["errors"][0]["title"], ApiErrors.VALIDATION_ERROR)
+        self.assertEqual(response.data["errors"][0]["detail"], ApiErrors.INVALID_TASK_ID_FORMAT_DETAIL)
+        mock_get_task_by_id.assert_called_once_with(invalid_task_id)
+
+    @patch("todo.services.task_service.TaskService.get_task_by_id")
+    def test_get_single_task_unexpected_error(self, mock_get_task_by_id: Mock):
+        task_id = str(ObjectId())
+        mock_get_task_by_id.side_effect = Exception("Some random error")
+
+        response = self.client.get(reverse("task_detail", args=[task_id]))
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.data["statusCode"], status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.data["message"], ApiErrors.UNEXPECTED_ERROR_OCCURRED)
+        self.assertEqual(response.data["errors"][0]["detail"], ApiErrors.INTERNAL_SERVER_ERROR)
+        mock_get_task_by_id.assert_called_once_with(task_id)
 
 
 class TaskViewTest(TestCase):

--- a/todo/urls.py
+++ b/todo/urls.py
@@ -5,5 +5,6 @@ from todo.views.health import HealthView
 
 urlpatterns = [
     path("tasks", TaskView.as_view(), name="tasks"),
+    path("tasks/<str:task_id>", TaskView.as_view(), name="task_detail"),
     path("health", HealthView.as_view(), name="health"),
 ]

--- a/todo_project/settings/base.py
+++ b/todo_project/settings/base.py
@@ -55,3 +55,10 @@ REST_FRAMEWORK = {
         "MAX_PAGE_LIMIT": 200,
     },
 }
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}


### PR DESCRIPTION


<!-- Date Here in dd mmm yyyy-->
Date: `May 24, 2025`
<!--Developer Name Here-->
Developer Name: @Achintya-Chatterjee 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #29 
## Description
<!--Description of the changes made in this PR-->
- Added `get_by_id` method to `TaskRepository`.
- Added `get_task_by_id` method to `TaskService` with error handling
  for `TaskNotFoundException` and invalid ObjectId format.
- Updated `TaskView` to handle requests for a single task ID,
  returning 404 for not found and 400 for invalid ID format.
- Added new URL pattern `/tasks/<str:task_id>` to `todo/urls.py`.
- Created `GetTaskByIdResponse` DTO for the response structure.
- Created `TaskNotFoundException` custom exception.
- Added `PATH` to `ApiErrorSource` enum for error reporting.
- Added new API error messages to `todo/constants/messages.py`.
- Added default SQLite `DATABASES` configuration to
  `todo_project/settings/base.py` to ensure Django's test runner
  operates correctly, resolving teardown errors.
- Added comprehensive unit tests for the new repository method,
  service method, and view logic.
- Added integration tests for the new endpoint, covering success (200),
  not found (404), and invalid ID format (400) scenarios.
### Documentation Updated?

- [ ] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>
<!-- Attach your screenshots here👇-->

https://github.com/user-attachments/assets/14b3c084-c4f3-4cd9-a7ba-c3ff4feace18


</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>
<!-- Attach your screenshots here👇-->
<img width="1148" alt="Screenshot 2025-05-24 at 00 45 24" src="https://github.com/user-attachments/assets/6ae42038-1f35-423b-998c-ddb5534b05ae" />

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
