### PR TITLE
chore: mark delete task API as deprecated

### DIFF
--- a/todo/views/task.py
+++ b/todo/views/task.py
@@ -95,6 +95,13 @@ class TaskDetailView(APIView):
         return Response(data=response_data.model_dump(mode="json"), status=status.HTTP_200_OK)
 
     def delete(self, request: Request, task_id: str):
+        """
+        Delete a task by ID.
+
+        .. deprecated:: 1.0.0
+            This endpoint is deprecated and will be removed in a future version.
+            Consider using the PATCH endpoint with action=delete instead.
+        """
         task_id = ObjectId(task_id)
         TaskService.delete_task(task_id)
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 28 Jun 2025
<!--Developer Name Here-->
Developer Name: @AnujChhikara 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->

## Description
- This PR marks the Delete Task by ID API as deprecated.

- As per the new product requirements, we no longer permanently delete tasks. Instead, tasks will be marked using a flag such as isClosed so similar to indicate their status.
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
