### PR TITLE
feat: set is_active to True for new team members upon team creation

### DIFF
--- a/todo/services/team_service.py
+++ b/todo/services/team_service.py
@@ -54,6 +54,7 @@ class TeamService:
                     user_id=PyObjectId(member_id),
                     team_id=created_team.id,
                     role_id=DEFAULT_ROLE_ID,
+                    is_active=True,
                     created_by=PyObjectId(created_by_user_id),
                     updated_by=PyObjectId(created_by_user_id),
                 )
@@ -65,6 +66,7 @@ class TeamService:
                     user_id=PyObjectId(dto.poc_id),
                     team_id=created_team.id,
                     role_id=DEFAULT_ROLE_ID,
+                    is_active=True,
                     created_by=PyObjectId(created_by_user_id),
                     updated_by=PyObjectId(created_by_user_id),
                 )
@@ -76,6 +78,7 @@ class TeamService:
                     user_id=PyObjectId(created_by_user_id),
                     team_id=created_team.id,
                     role_id=DEFAULT_ROLE_ID,
+                    is_active=True,
                     created_by=PyObjectId(created_by_user_id),
                     updated_by=PyObjectId(created_by_user_id),
                 )


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Set the `is_active` flag to `True` for new team members when a team is created.

### Why are these changes being made?

This change ensures that all new team members are active by default, which aligns with the expected behavior for newly added members, reducing the need for additional updates post team creation. This approach simplifies the member activation process and maintains consistency across the platform.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->