### PR TITLE
feat: update task DTO preparation to include user ID in task service …

### DIFF
--- a/todo/tests/unit/services/test_task_service.py
+++ b/todo/tests/unit/services/test_task_service.py
@@ -704,7 +704,7 @@ class TaskServiceDeferTests(TestCase):
         self.assertEqual(result_dto, mock_dto)
         mock_repo_get_by_id.assert_called_once_with(self.task_id)
         mock_repo_update.assert_called_once()
-        mock_prepare_dto.assert_called_once_with(mock_updated_task, 'system_user')
+        mock_prepare_dto.assert_called_once_with(mock_updated_task, "system_user")
 
         update_call_args = mock_repo_update.call_args[0]
         self.assertEqual(update_call_args[0], self.task_id)

--- a/todo/tests/unit/services/test_task_service.py
+++ b/todo/tests/unit/services/test_task_service.py
@@ -230,7 +230,7 @@ class TaskServiceTests(AuthenticatedMongoTestCase):
         mock_create.assert_called_once()
         created_task_model_arg = mock_create.call_args[0][0]
         self.assertIsNone(created_task_model_arg.deferredDetails)
-        mock_prepare_dto.assert_called_once_with(mock_task_model)
+        mock_prepare_dto.assert_called_once_with(mock_task_model, str(self.user_id))
         self.assertEqual(result.data, mock_task_dto)
 
     @patch("todo.services.task_service.TaskRepository.get_by_id")
@@ -246,7 +246,7 @@ class TaskServiceTests(AuthenticatedMongoTestCase):
         result_dto = TaskService.get_task_by_id(task_id)
 
         mock_repo_get_by_id.assert_called_once_with(task_id)
-        mock_prepare_task_dto.assert_called_once_with(mock_task_model)
+        mock_prepare_task_dto.assert_called_once_with(mock_task_model, user_id=None)
         self.assertEqual(result_dto, mock_dto)
 
     @patch("todo.services.task_service.TaskRepository.get_by_id")
@@ -704,7 +704,7 @@ class TaskServiceDeferTests(TestCase):
         self.assertEqual(result_dto, mock_dto)
         mock_repo_get_by_id.assert_called_once_with(self.task_id)
         mock_repo_update.assert_called_once()
-        mock_prepare_dto.assert_called_once_with(mock_updated_task)
+        mock_prepare_dto.assert_called_once_with(mock_updated_task, 'system_user')
 
         update_call_args = mock_repo_update.call_args[0]
         self.assertEqual(update_call_args[0], self.task_id)


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the task DTO preparation to include an additional argument for user ID in the TaskService.

### Why are these changes being made?

The task service needs to incorporate user-specific context in its operations, particularly for preparing DTOs; by including user IDs, it can handle tasks with more specific user-related logic. This enhances the ability to track actions in a user-centric manner and ensures more precise handling of user-related data, which is crucial for accurate task management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->