### PR TITLE
feat: add endpoint and logic for joining a team by invite code

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -624,6 +624,48 @@ paths:
           description: Team not found
         '500':
           description: Internal server error
+  /v1/teams/join-by-invite:
+    post:
+      operationId: join_team_by_invite_code
+      description: Join a team using a valid invite code. Returns the joined team details.
+      summary: Join a team by invite code
+      tags:
+        - teams
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JoinTeamByInviteCodeRequest'
+        required: true
+      security:
+        - cookieAuth: []
+        - basicAuth: []
+        - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamDTO'
+          description: Joined team successfully
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Bad request - validation error or already a member
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Team not found or invalid invite code
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Internal server error
   /v1/users:
     get:
       operationId: get_users
@@ -1699,6 +1741,16 @@ components:
       - watchlistId
       title: WatchlistDTO
       type: object
+    JoinTeamByInviteCodeRequest:
+      type: object
+      properties:
+        invite_code:
+          type: string
+          minLength: 1
+          maxLength: 100
+      required:
+        - invite_code
+      description: Request body for joining a team by invite code.
   securitySchemes:
     basicAuth:
       type: http

--- a/todo/repositories/team_repository.py
+++ b/todo/repositories/team_repository.py
@@ -37,6 +37,20 @@ class TeamRepository(MongoRepository):
         except Exception:
             return None
 
+    @classmethod
+    def get_by_invite_code(cls, invite_code: str) -> Optional[TeamModel]:
+        """
+        Get a team by its invite code.
+        """
+        teams_collection = cls.get_collection()
+        try:
+            team_data = teams_collection.find_one({"invite_code": invite_code, "is_deleted": False})
+            if team_data:
+                return TeamModel(**team_data)
+            return None
+        except Exception:
+            return None
+
 
 class UserTeamDetailsRepository(MongoRepository):
     collection_name = UserTeamDetailsModel.collection_name

--- a/todo/serializers/create_team_serializer.py
+++ b/todo/serializers/create_team_serializer.py
@@ -26,3 +26,7 @@ class CreateTeamSerializer(serializers.Serializer):
             if not ObjectId.is_valid(member_id):
                 raise serializers.ValidationError(ValidationErrors.INVALID_OBJECT_ID.format(member_id))
         return value
+
+
+class JoinTeamByInviteCodeSerializer(serializers.Serializer):
+    invite_code = serializers.CharField(max_length=100)

--- a/todo/tests/unit/services/test_team_service.py
+++ b/todo/tests/unit/services/test_team_service.py
@@ -128,3 +128,39 @@ class TeamServiceTests(TestCase):
         user_team_objs = mock_create_many.call_args[0][0]
         all_user_ids = [str(obj.user_id) for obj in user_team_objs]
         self.assertIn(creator_id, all_user_ids)
+
+    @patch("todo.services.team_service.TeamRepository.get_by_invite_code")
+    @patch("todo.services.team_service.UserTeamDetailsRepository.get_by_user_id")
+    @patch("todo.services.team_service.UserTeamDetailsRepository.create")
+    def test_join_team_by_invite_code_success(self, mock_create, mock_get_by_user_id, mock_get_by_invite_code):
+        """Test successful join by invite code"""
+        mock_get_by_invite_code.return_value = self.team_model
+        mock_get_by_user_id.return_value = []  # Not a member yet
+        mock_create.return_value = self.user_team_details
+
+        from todo.services.team_service import TeamService
+        team_dto = TeamService.join_team_by_invite_code("TEST123", self.user_id)
+        self.assertEqual(team_dto.id, self.team_id)
+        self.assertEqual(team_dto.name, "Test Team")
+        mock_get_by_invite_code.assert_called_once_with("TEST123")
+        mock_create.assert_called_once()
+
+    @patch("todo.services.team_service.TeamRepository.get_by_invite_code")
+    def test_join_team_by_invite_code_invalid_code(self, mock_get_by_invite_code):
+        """Test join by invite code with invalid code"""
+        mock_get_by_invite_code.return_value = None
+        from todo.services.team_service import TeamService
+        with self.assertRaises(ValueError) as context:
+            TeamService.join_team_by_invite_code("INVALID", self.user_id)
+        self.assertIn("Invalid invite code", str(context.exception))
+
+    @patch("todo.services.team_service.TeamRepository.get_by_invite_code")
+    @patch("todo.services.team_service.UserTeamDetailsRepository.get_by_user_id")
+    def test_join_team_by_invite_code_already_member(self, mock_get_by_user_id, mock_get_by_invite_code):
+        """Test join by invite code when already a member"""
+        mock_get_by_invite_code.return_value = self.team_model
+        mock_get_by_user_id.return_value = [self.user_team_details]  # Already a member
+        from todo.services.team_service import TeamService
+        with self.assertRaises(ValueError) as context:
+            TeamService.join_team_by_invite_code("TEST123", self.user_id)
+        self.assertIn("already a member", str(context.exception))

--- a/todo/urls.py
+++ b/todo/urls.py
@@ -5,12 +5,13 @@ from todo.views.user import UsersView
 from todo.views.auth import GoogleLoginView, GoogleCallbackView, LogoutView
 from todo.views.role import RoleListView, RoleDetailView
 from todo.views.label import LabelListView
-from todo.views.team import TeamListView, TeamDetailView
+from todo.views.team import TeamListView, TeamDetailView, JoinTeamByInviteCodeView
 from todo.views.watchlist import WatchlistListView, WatchlistDetailView, WatchlistCheckView
 from todo.views.task_assignment import TaskAssignmentView, TaskAssignmentDetailView
 
 urlpatterns = [
     path("teams", TeamListView.as_view(), name="teams"),
+    path("teams/join-by-invite", JoinTeamByInviteCodeView.as_view(), name="join_team_by_invite"),
     path("teams/<str:team_id>", TeamDetailView.as_view(), name="team_detail"),
     path("tasks", TaskListView.as_view(), name="tasks"),
     path("tasks/<str:task_id>", TaskDetailView.as_view(), name="task_detail"),


### PR DESCRIPTION
- Introduced a new API endpoint `/v1/teams/join-by-invite` to allow users to join teams using a valid invite code.
- Implemented the `JoinTeamByInviteCode` view, including request validation and response handling.
- Added corresponding service and repository methods to handle team retrieval by invite code and user membership checks.
- Created a serializer for invite code requests and updated the OpenAPI schema documentation accordingly.
- Added unit tests to ensure functionality and error handling for the new feature.

