### PR TITLE
feat: add teamId filter to task retrieval and update related logic

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -408,6 +408,11 @@ paths:
         schema:
           type: integer
         description: Page number for pagination
+      - in: query
+        name: teamId
+        schema:
+          type: string
+        description: 'If provided, filters tasks assigned to this team.'
       tags:
       - tasks
       security:

--- a/todo/repositories/task_repository.py
+++ b/todo/repositories/task_repository.py
@@ -15,12 +15,15 @@ class TaskRepository(MongoRepository):
     collection_name = TaskModel.collection_name
 
     @classmethod
-    def list(cls, page: int, limit: int, sort_by: str, order: str, user_id: str = None, team_id: str = None) -> List[TaskModel]:
+    def list(
+        cls, page: int, limit: int, sort_by: str, order: str, user_id: str = None, team_id: str = None
+    ) -> List[TaskModel]:
         tasks_collection = cls.get_collection()
 
         if team_id:
             # Get all task IDs assigned to this team
             from todo.repositories.assignee_task_details_repository import AssigneeTaskDetailsRepository
+
             team_assignments = AssigneeTaskDetailsRepository.get_by_assignee_id(team_id, "team")
             team_task_ids = [assignment.task_id for assignment in team_assignments]
             query_filter = {"_id": {"$in": team_task_ids}}
@@ -69,6 +72,7 @@ class TaskRepository(MongoRepository):
         tasks_collection = cls.get_collection()
         if team_id:
             from todo.repositories.assignee_task_details_repository import AssigneeTaskDetailsRepository
+
             team_assignments = AssigneeTaskDetailsRepository.get_by_assignee_id(team_id, "team")
             team_task_ids = [assignment.task_id for assignment in team_assignments]
             query_filter = {"_id": {"$in": team_task_ids}}

--- a/todo/repositories/task_repository.py
+++ b/todo/repositories/task_repository.py
@@ -15,10 +15,16 @@ class TaskRepository(MongoRepository):
     collection_name = TaskModel.collection_name
 
     @classmethod
-    def list(cls, page: int, limit: int, sort_by: str, order: str, user_id: str = None) -> List[TaskModel]:
+    def list(cls, page: int, limit: int, sort_by: str, order: str, user_id: str = None, team_id: str = None) -> List[TaskModel]:
         tasks_collection = cls.get_collection()
 
-        if user_id:
+        if team_id:
+            # Get all task IDs assigned to this team
+            from todo.repositories.assignee_task_details_repository import AssigneeTaskDetailsRepository
+            team_assignments = AssigneeTaskDetailsRepository.get_by_assignee_id(team_id, "team")
+            team_task_ids = [assignment.task_id for assignment in team_assignments]
+            query_filter = {"_id": {"$in": team_task_ids}}
+        elif user_id:
             assigned_task_ids = cls._get_assigned_task_ids_for_user(user_id)
             query_filter = {"$or": [{"createdBy": user_id}, {"_id": {"$in": assigned_task_ids}}]}
         else:
@@ -59,9 +65,14 @@ class TaskRepository(MongoRepository):
         return direct_task_ids + team_task_ids
 
     @classmethod
-    def count(cls, user_id: str = None) -> int:
+    def count(cls, user_id: str = None, team_id: str = None) -> int:
         tasks_collection = cls.get_collection()
-        if user_id:
+        if team_id:
+            from todo.repositories.assignee_task_details_repository import AssigneeTaskDetailsRepository
+            team_assignments = AssigneeTaskDetailsRepository.get_by_assignee_id(team_id, "team")
+            team_task_ids = [assignment.task_id for assignment in team_assignments]
+            query_filter = {"_id": {"$in": team_task_ids}}
+        elif user_id:
             assigned_task_ids = cls._get_assigned_task_ids_for_user(user_id)
             query_filter = {"$or": [{"createdBy": user_id}, {"_id": {"$in": assigned_task_ids}}]}
         else:

--- a/todo/serializers/get_tasks_serializer.py
+++ b/todo/serializers/get_tasks_serializer.py
@@ -35,6 +35,8 @@ class GetTaskQueryParamsSerializer(serializers.Serializer):
         required=False,
     )
 
+    teamId = serializers.CharField(required=False, allow_blank=False, allow_null=True)
+
     def validate(self, attrs):
         validated_data = super().validate(attrs)
 

--- a/todo/services/task_service.py
+++ b/todo/services/task_service.py
@@ -59,13 +59,13 @@ class TaskService:
         sort_by: str,
         order: str,
         user_id: str,
+        team_id: str = None,
     ) -> GetTasksResponse:
         try:
             cls._validate_pagination_params(page, limit)
 
-            tasks = TaskRepository.list(page, limit, sort_by, order, user_id)
-
-            total_count = TaskRepository.count(user_id)
+            tasks = TaskRepository.list(page, limit, sort_by, order, user_id, team_id=team_id)
+            total_count = TaskRepository.count(user_id, team_id=team_id)
 
             if not tasks:
                 return GetTasksResponse(tasks=[], links=None)

--- a/todo/tests/integration/test_task_sorting_integration.py
+++ b/todo/tests/integration/test_task_sorting_integration.py
@@ -24,7 +24,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
         response = self.client.get("/v1/tasks", {"sort_by": "priority", "order": "desc"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_list.assert_called_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, str(self.user_id), None)
+        mock_list.assert_called_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, str(self.user_id), team_id=None)
 
     @patch("todo.repositories.task_repository.TaskRepository.count")
     @patch("todo.repositories.task_repository.TaskRepository.list")
@@ -36,7 +36,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        mock_list.assert_called_with(1, 20, SORT_FIELD_DUE_AT, SORT_ORDER_ASC, str(self.user_id), None)
+        mock_list.assert_called_with(1, 20, SORT_FIELD_DUE_AT, SORT_ORDER_ASC, str(self.user_id), team_id=None)
 
     @patch("todo.repositories.task_repository.TaskRepository.count")
     @patch("todo.repositories.task_repository.TaskRepository.list")
@@ -49,7 +49,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Assignee sorting now falls back to createdAt sorting
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_ASSIGNEE, SORT_ORDER_ASC, str(self.user_id), None)
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_ASSIGNEE, SORT_ORDER_ASC, str(self.user_id), team_id=None)
 
     @patch("todo.repositories.task_repository.TaskRepository.count")
     @patch("todo.repositories.task_repository.TaskRepository.list")
@@ -72,7 +72,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
                 response = self.client.get("/v1/tasks", {"sort_by": sort_field})
 
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
-                mock_list.assert_called_with(1, 20, sort_field, expected_order, str(self.user_id), None)
+                mock_list.assert_called_with(1, 20, sort_field, expected_order, str(self.user_id), team_id=None)
 
     @patch("todo.repositories.task_repository.TaskRepository.count")
     @patch("todo.repositories.task_repository.TaskRepository.list")
@@ -84,7 +84,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        mock_list.assert_called_with(3, 5, SORT_FIELD_CREATED_AT, SORT_ORDER_ASC, str(self.user_id), None)
+        mock_list.assert_called_with(3, 5, SORT_FIELD_CREATED_AT, SORT_ORDER_ASC, str(self.user_id), team_id=None)
 
     def test_invalid_sort_parameters_integration(self):
         response = self.client.get("/v1/tasks", {"sort_by": "invalid_field"})
@@ -103,7 +103,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        mock_list.assert_called_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, str(self.user_id), None)
+        mock_list.assert_called_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, str(self.user_id), team_id=None)
 
     @patch("todo.services.task_service.reverse_lazy", return_value="/v1/tasks")
     @patch("todo.repositories.task_repository.TaskRepository.count")

--- a/todo/tests/integration/test_task_sorting_integration.py
+++ b/todo/tests/integration/test_task_sorting_integration.py
@@ -24,7 +24,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
         response = self.client.get("/v1/tasks", {"sort_by": "priority", "order": "desc"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_list.assert_called_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, str(self.user_id))
+        mock_list.assert_called_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, str(self.user_id), None)
 
     @patch("todo.repositories.task_repository.TaskRepository.count")
     @patch("todo.repositories.task_repository.TaskRepository.list")
@@ -36,7 +36,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        mock_list.assert_called_with(1, 20, SORT_FIELD_DUE_AT, SORT_ORDER_ASC, str(self.user_id))
+        mock_list.assert_called_with(1, 20, SORT_FIELD_DUE_AT, SORT_ORDER_ASC, str(self.user_id), None)
 
     @patch("todo.repositories.task_repository.TaskRepository.count")
     @patch("todo.repositories.task_repository.TaskRepository.list")
@@ -49,7 +49,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Assignee sorting now falls back to createdAt sorting
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_ASSIGNEE, SORT_ORDER_ASC, str(self.user_id))
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_ASSIGNEE, SORT_ORDER_ASC, str(self.user_id), None)
 
     @patch("todo.repositories.task_repository.TaskRepository.count")
     @patch("todo.repositories.task_repository.TaskRepository.list")
@@ -72,7 +72,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
                 response = self.client.get("/v1/tasks", {"sort_by": sort_field})
 
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
-                mock_list.assert_called_with(1, 20, sort_field, expected_order, str(self.user_id))
+                mock_list.assert_called_with(1, 20, sort_field, expected_order, str(self.user_id), None)
 
     @patch("todo.repositories.task_repository.TaskRepository.count")
     @patch("todo.repositories.task_repository.TaskRepository.list")
@@ -84,7 +84,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        mock_list.assert_called_with(3, 5, SORT_FIELD_CREATED_AT, SORT_ORDER_ASC, str(self.user_id))
+        mock_list.assert_called_with(3, 5, SORT_FIELD_CREATED_AT, SORT_ORDER_ASC, str(self.user_id), None)
 
     def test_invalid_sort_parameters_integration(self):
         response = self.client.get("/v1/tasks", {"sort_by": "invalid_field"})
@@ -103,7 +103,7 @@ class TaskSortingIntegrationTest(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        mock_list.assert_called_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, str(self.user_id))
+        mock_list.assert_called_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, str(self.user_id), None)
 
     @patch("todo.services.task_service.reverse_lazy", return_value="/v1/tasks")
     @patch("todo.repositories.task_repository.TaskRepository.count")

--- a/todo/tests/integration/test_tasks_pagination.py
+++ b/todo/tests/integration/test_tasks_pagination.py
@@ -21,7 +21,7 @@ class TaskPaginationIntegrationTest(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, 200)
         mock_get_tasks.assert_called_with(
-            page=1, limit=default_limit, sort_by="createdAt", order="desc", user_id=str(self.user_id)
+            page=1, limit=default_limit, sort_by="createdAt", order="desc", user_id=str(self.user_id), team_id=None
         )
 
         mock_get_tasks.reset_mock()
@@ -30,7 +30,7 @@ class TaskPaginationIntegrationTest(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, 200)
         mock_get_tasks.assert_called_with(
-            page=1, limit=10, sort_by="createdAt", order="desc", user_id=str(self.user_id)
+            page=1, limit=10, sort_by="createdAt", order="desc", user_id=str(self.user_id), team_id=None
         )
 
         # Verify API rejects values above max limit

--- a/todo/tests/unit/services/test_task_service.py
+++ b/todo/tests/unit/services/test_task_service.py
@@ -70,7 +70,7 @@ class TaskServiceTests(AuthenticatedMongoTestCase):
             response.links.prev, f"{self.mock_reverse_lazy('tasks')}?page=1&limit=1&sort_by=createdAt&order=desc"
         )
 
-        mock_list.assert_called_once_with(2, 1, "createdAt", "desc", str(self.user_id), None)
+        mock_list.assert_called_once_with(2, 1, "createdAt", "desc", str(self.user_id), team_id=None)
         mock_count.assert_called_once()
 
     @patch("todo.services.task_service.UserRepository.get_by_id")
@@ -110,7 +110,7 @@ class TaskServiceTests(AuthenticatedMongoTestCase):
         self.assertEqual(len(response.tasks), 0)
         self.assertIsNone(response.links)
 
-        mock_list.assert_called_once_with(1, 10, "createdAt", "desc", "test_user", None)
+        mock_list.assert_called_once_with(1, 10, "createdAt", "desc", "test_user", team_id=None)
         mock_count.assert_called_once()
 
     @patch("todo.services.task_service.TaskRepository.count")
@@ -293,7 +293,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by="createdAt", order="desc", user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, "test_user", None)
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, "test_user", team_id=None)
 
     @patch("todo.services.task_service.TaskRepository.count")
     @patch("todo.services.task_service.TaskRepository.list")
@@ -303,7 +303,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by=SORT_FIELD_PRIORITY, order=SORT_ORDER_DESC, user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, "test_user", None)
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, "test_user", team_id=None)
 
     @patch("todo.services.task_service.TaskRepository.count")
     @patch("todo.services.task_service.TaskRepository.list")
@@ -313,7 +313,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by=SORT_FIELD_DUE_AT, order="asc", user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_DUE_AT, SORT_ORDER_ASC, "test_user", None)
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_DUE_AT, SORT_ORDER_ASC, "test_user", team_id=None)
 
     @patch("todo.services.task_service.TaskRepository.count")
     @patch("todo.services.task_service.TaskRepository.list")
@@ -323,7 +323,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by=SORT_FIELD_PRIORITY, order="desc", user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, "test_user", None)
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, "test_user", team_id=None)
 
     @patch("todo.services.task_service.TaskRepository.count")
     @patch("todo.services.task_service.TaskRepository.list")
@@ -333,7 +333,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by=SORT_FIELD_ASSIGNEE, order="asc", user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_ASSIGNEE, SORT_ORDER_ASC, "test_user", None)
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_ASSIGNEE, SORT_ORDER_ASC, "test_user", team_id=None)
 
     @patch("todo.services.task_service.TaskRepository.count")
     @patch("todo.services.task_service.TaskRepository.list")
@@ -343,7 +343,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by=SORT_FIELD_CREATED_AT, order="desc", user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, "test_user", None)
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, "test_user", team_id=None)
 
     @patch("todo.services.task_service.reverse_lazy", return_value="/v1/tasks")
     def test_build_page_url_includes_sort_parameters(self, mock_reverse):

--- a/todo/tests/unit/services/test_task_service.py
+++ b/todo/tests/unit/services/test_task_service.py
@@ -70,7 +70,7 @@ class TaskServiceTests(AuthenticatedMongoTestCase):
             response.links.prev, f"{self.mock_reverse_lazy('tasks')}?page=1&limit=1&sort_by=createdAt&order=desc"
         )
 
-        mock_list.assert_called_once_with(2, 1, "createdAt", "desc", str(self.user_id))
+        mock_list.assert_called_once_with(2, 1, "createdAt", "desc", str(self.user_id), None)
         mock_count.assert_called_once()
 
     @patch("todo.services.task_service.UserRepository.get_by_id")
@@ -110,7 +110,7 @@ class TaskServiceTests(AuthenticatedMongoTestCase):
         self.assertEqual(len(response.tasks), 0)
         self.assertIsNone(response.links)
 
-        mock_list.assert_called_once_with(1, 10, "createdAt", "desc", "test_user")
+        mock_list.assert_called_once_with(1, 10, "createdAt", "desc", "test_user", None)
         mock_count.assert_called_once()
 
     @patch("todo.services.task_service.TaskRepository.count")
@@ -293,7 +293,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by="createdAt", order="desc", user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, "test_user")
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, "test_user", None)
 
     @patch("todo.services.task_service.TaskRepository.count")
     @patch("todo.services.task_service.TaskRepository.list")
@@ -303,7 +303,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by=SORT_FIELD_PRIORITY, order=SORT_ORDER_DESC, user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, "test_user")
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, "test_user", None)
 
     @patch("todo.services.task_service.TaskRepository.count")
     @patch("todo.services.task_service.TaskRepository.list")
@@ -313,7 +313,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by=SORT_FIELD_DUE_AT, order="asc", user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_DUE_AT, SORT_ORDER_ASC, "test_user")
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_DUE_AT, SORT_ORDER_ASC, "test_user", None)
 
     @patch("todo.services.task_service.TaskRepository.count")
     @patch("todo.services.task_service.TaskRepository.list")
@@ -323,7 +323,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by=SORT_FIELD_PRIORITY, order="desc", user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, "test_user")
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_PRIORITY, SORT_ORDER_DESC, "test_user", None)
 
     @patch("todo.services.task_service.TaskRepository.count")
     @patch("todo.services.task_service.TaskRepository.list")
@@ -333,7 +333,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by=SORT_FIELD_ASSIGNEE, order="asc", user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_ASSIGNEE, SORT_ORDER_ASC, "test_user")
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_ASSIGNEE, SORT_ORDER_ASC, "test_user", None)
 
     @patch("todo.services.task_service.TaskRepository.count")
     @patch("todo.services.task_service.TaskRepository.list")
@@ -343,7 +343,7 @@ class TaskServiceSortingTests(TestCase):
 
         TaskService.get_tasks(page=1, limit=20, sort_by=SORT_FIELD_CREATED_AT, order="desc", user_id="test_user")
 
-        mock_list.assert_called_once_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, "test_user")
+        mock_list.assert_called_once_with(1, 20, SORT_FIELD_CREATED_AT, SORT_ORDER_DESC, "test_user", None)
 
     @patch("todo.services.task_service.reverse_lazy", return_value="/v1/tasks")
     def test_build_page_url_includes_sort_parameters(self, mock_reverse):

--- a/todo/tests/unit/views/test_task.py
+++ b/todo/tests/unit/views/test_task.py
@@ -318,7 +318,12 @@ class TaskViewSortingTests(AuthenticatedMongoTestCase):
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             mock_get_tasks.assert_called_once_with(
-                page=1, limit=20, sort_by=SORT_FIELD_CREATED_AT, order=SORT_ORDER_ASC, user_id=str(self.user_id), team_id=None
+                page=1,
+                limit=20,
+                sort_by=SORT_FIELD_CREATED_AT,
+                order=SORT_ORDER_ASC,
+                user_id=str(self.user_id),
+                team_id=None,
             )
 
 

--- a/todo/tests/unit/views/test_task.py
+++ b/todo/tests/unit/views/test_task.py
@@ -45,7 +45,7 @@ class TaskViewTests(AuthenticatedMongoTestCase):
         response: Response = self.client.get(self.url, self.valid_params)
 
         mock_get_tasks.assert_called_once_with(
-            page=1, limit=10, sort_by="createdAt", order="desc", user_id=str(self.user_id)
+            page=1, limit=10, sort_by="createdAt", order="desc", user_id=str(self.user_id), team_id=None
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected_response = mock_get_tasks.return_value.model_dump(mode="json")
@@ -58,7 +58,7 @@ class TaskViewTests(AuthenticatedMongoTestCase):
         response: Response = self.client.get(self.url)
         default_limit = settings.REST_FRAMEWORK["DEFAULT_PAGINATION_SETTINGS"]["DEFAULT_PAGE_LIMIT"]
         mock_get_tasks.assert_called_once_with(
-            page=1, limit=default_limit, sort_by="createdAt", order="desc", user_id=str(self.user_id)
+            page=1, limit=default_limit, sort_by="createdAt", order="desc", user_id=str(self.user_id), team_id=None
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -163,7 +163,7 @@ class TaskViewTest(AuthenticatedMongoTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         default_limit = settings.REST_FRAMEWORK["DEFAULT_PAGINATION_SETTINGS"]["DEFAULT_PAGE_LIMIT"]
         mock_get_tasks.assert_called_once_with(
-            page=1, limit=default_limit, sort_by="createdAt", order="desc", user_id=str(self.user_id)
+            page=1, limit=default_limit, sort_by="createdAt", order="desc", user_id=str(self.user_id), team_id=None
         )
 
     @patch("todo.services.task_service.TaskService.get_tasks")
@@ -175,7 +175,7 @@ class TaskViewTest(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_get_tasks.assert_called_once_with(
-            page=2, limit=15, sort_by="createdAt", order="desc", user_id=str(self.user_id)
+            page=2, limit=15, sort_by="createdAt", order="desc", user_id=str(self.user_id), team_id=None
         )
 
     def test_get_tasks_with_invalid_page(self):
@@ -217,7 +217,7 @@ class TaskViewSortingTests(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_get_tasks.assert_called_once_with(
-            page=1, limit=20, sort_by=SORT_FIELD_PRIORITY, order="desc", user_id=str(self.user_id)
+            page=1, limit=20, sort_by=SORT_FIELD_PRIORITY, order="desc", user_id=str(self.user_id), team_id=None
         )
 
     @patch("todo.services.task_service.TaskService.get_tasks")
@@ -228,7 +228,7 @@ class TaskViewSortingTests(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_get_tasks.assert_called_once_with(
-            page=1, limit=20, sort_by=SORT_FIELD_DUE_AT, order=SORT_ORDER_DESC, user_id=str(self.user_id)
+            page=1, limit=20, sort_by=SORT_FIELD_DUE_AT, order=SORT_ORDER_DESC, user_id=str(self.user_id), team_id=None
         )
 
     @patch("todo.services.task_service.TaskService.get_tasks")
@@ -250,7 +250,7 @@ class TaskViewSortingTests(AuthenticatedMongoTestCase):
 
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
                 mock_get_tasks.assert_called_once_with(
-                    page=1, limit=20, sort_by=sort_field, order=expected_order, user_id=str(self.user_id)
+                    page=1, limit=20, sort_by=sort_field, order=expected_order, user_id=str(self.user_id), team_id=None
                 )
 
     @patch("todo.services.task_service.TaskService.get_tasks")
@@ -267,7 +267,7 @@ class TaskViewSortingTests(AuthenticatedMongoTestCase):
 
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
                 mock_get_tasks.assert_called_once_with(
-                    page=1, limit=20, sort_by=SORT_FIELD_PRIORITY, order=order, user_id=str(self.user_id)
+                    page=1, limit=20, sort_by=SORT_FIELD_PRIORITY, order=order, user_id=str(self.user_id), team_id=None
                 )
 
     def test_get_tasks_with_invalid_sort_by(self):
@@ -296,7 +296,7 @@ class TaskViewSortingTests(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_get_tasks.assert_called_once_with(
-            page=2, limit=15, sort_by=SORT_FIELD_DUE_AT, order=SORT_ORDER_ASC, user_id=str(self.user_id)
+            page=2, limit=15, sort_by=SORT_FIELD_DUE_AT, order=SORT_ORDER_ASC, user_id=str(self.user_id), team_id=None
         )
 
     @patch("todo.services.task_service.TaskService.get_tasks")
@@ -307,7 +307,7 @@ class TaskViewSortingTests(AuthenticatedMongoTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_get_tasks.assert_called_once_with(
-            page=1, limit=20, sort_by=SORT_FIELD_CREATED_AT, order="desc", user_id=str(self.user_id)
+            page=1, limit=20, sort_by=SORT_FIELD_CREATED_AT, order="desc", user_id=str(self.user_id), team_id=None
         )
 
     def test_get_tasks_edge_case_combinations(self):
@@ -318,7 +318,7 @@ class TaskViewSortingTests(AuthenticatedMongoTestCase):
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             mock_get_tasks.assert_called_once_with(
-                page=1, limit=20, sort_by=SORT_FIELD_CREATED_AT, order=SORT_ORDER_ASC, user_id=str(self.user_id)
+                page=1, limit=20, sort_by=SORT_FIELD_CREATED_AT, order=SORT_ORDER_ASC, user_id=str(self.user_id), team_id=None
             )
 
 

--- a/todo/views/task.py
+++ b/todo/views/task.py
@@ -45,6 +45,13 @@ class TaskListView(APIView):
                 location=OpenApiParameter.QUERY,
                 description="Number of tasks per page",
             ),
+            OpenApiParameter(
+                name="teamId",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="If provided, filters tasks assigned to this team.",
+                required=False,
+            ),
         ],
         responses={
             200: OpenApiResponse(response=GetTasksResponse, description="Successful response"),
@@ -81,12 +88,14 @@ class TaskListView(APIView):
                 status=status.HTTP_200_OK,
             )
 
+        team_id = query.validated_data.get("teamId")
         response = TaskService.get_tasks(
             page=query.validated_data["page"],
             limit=query.validated_data["limit"],
             sort_by=query.validated_data["sort_by"],
             order=query.validated_data.get("order"),
             user_id=user["user_id"],
+            team_id=team_id,
         )
         return Response(data=response.model_dump(mode="json"), status=status.HTTP_200_OK)
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a `teamId` filter to task retrieval functionality and update the associated logic in the repositories, serializers, services, and API views to support this new filter.

### Why are these changes being made?
The changes enhance the task management system by allowing users to filter tasks based on the team to which they are assigned, which supports better organization and management of tasks in environments where team-based task assignment is prevalent. This approach leverages existing task-assignee relationships and integrates the new filter seamlessly into the existing task querying logic.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->