### PR TITLE
fix: update assignee task retrieval to handle ObjectId conversion

### DIFF
--- a/todo/repositories/assignee_task_details_repository.py
+++ b/todo/repositories/assignee_task_details_repository.py
@@ -44,10 +44,21 @@ class AssigneeTaskDetailsRepository(MongoRepository):
         """
         collection = cls.get_collection()
         try:
-            assignee_tasks_data = collection.find(
-                {"assignee_id": assignee_id, "relation_type": relation_type, "is_active": True}
-            )
-            return [AssigneeTaskDetailsModel(**data) for data in assignee_tasks_data]
+          
+            from bson import ObjectId
+            results = list(collection.find({
+                "assignee_id": ObjectId(assignee_id),
+                "relation_type": relation_type,
+                "is_active": True
+            }))
+            if not results:
+                
+                results = list(collection.find({
+                    "assignee_id": assignee_id,
+                    "relation_type": relation_type,
+                    "is_active": True
+                }))
+            return [AssigneeTaskDetailsModel(**data) for data in results]
         except Exception:
             return []
 

--- a/todo/repositories/assignee_task_details_repository.py
+++ b/todo/repositories/assignee_task_details_repository.py
@@ -44,20 +44,17 @@ class AssigneeTaskDetailsRepository(MongoRepository):
         """
         collection = cls.get_collection()
         try:
-          
             from bson import ObjectId
-            results = list(collection.find({
-                "assignee_id": ObjectId(assignee_id),
-                "relation_type": relation_type,
-                "is_active": True
-            }))
+
+            results = list(
+                collection.find(
+                    {"assignee_id": ObjectId(assignee_id), "relation_type": relation_type, "is_active": True}
+                )
+            )
             if not results:
-                
-                results = list(collection.find({
-                    "assignee_id": assignee_id,
-                    "relation_type": relation_type,
-                    "is_active": True
-                }))
+                results = list(
+                    collection.find({"assignee_id": assignee_id, "relation_type": relation_type, "is_active": True})
+                )
             return [AssigneeTaskDetailsModel(**data) for data in results]
         except Exception:
             return []


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the `get_by_assignee_id` method in the `assignee_task_details_repository` to handle `ObjectId` conversion for `assignee_id` retrieval in MongoDB queries.

### Why are these changes being made?
The change ensures that the method can correctly find documents using both the `ObjectId` and string representations of `assignee_id`, improving robustness of database queries where `assignee_id` can be stored as either type. This approach minimizes errors during lookup and ensures better compatibility with existing data.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->