### PR TITLE
feat: add endpoint to set or update executor for team-assigned tasks

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -357,6 +357,70 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
           description: Internal server error
+    patch:
+      operationId: set_executor_for_team_task
+      summary: Set or update executor for a team-assigned task (SPOC only)
+      description: |
+        Allows the SPOC of a team to set or update the executor (user within the team) for a team-assigned task.
+        All SPOC re-assignments are logged in the audit trail.
+      tags:
+        - task-assignments
+      parameters:
+        - in: path
+          name: task_id
+          schema:
+            type: string
+          required: true
+          description: Unique identifier of the task
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                executor_id:
+                  type: string
+                  description: User ID of the new executor (must be a member of the team)
+              required:
+                - executor_id
+      responses:
+        '200':
+          description: Executor updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '403':
+          description: Forbidden - only SPOC can update executor for team task
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        '404':
+          description: Task assignment not found or not a team assignment
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
     delete:
       operationId: delete_task_assignment
       description: Remove the assignment for a specific task

--- a/schema.yaml
+++ b/schema.yaml
@@ -359,68 +359,43 @@ paths:
           description: Internal server error
     patch:
       operationId: set_executor_for_team_task
+      description: Allows the SPOC of a team to set or update the executor (user within
+        the team) for a team-assigned task. All SPOC re-assignments are logged in
+        the audit trail.
       summary: Set or update executor for a team-assigned task (SPOC only)
-      description: |
-        Allows the SPOC of a team to set or update the executor (user within the team) for a team-assigned task.
-        All SPOC re-assignments are logged in the audit trail.
-      tags:
-        - task-assignments
       parameters:
-        - in: path
-          name: task_id
-          schema:
-            type: string
-          required: true
-          description: Unique identifier of the task
-      requestBody:
+      - in: path
+        name: task_id
+        schema:
+          type: string
+        description: Unique identifier of the task
         required: true
+      tags:
+      - task-assignments
+      requestBody:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                executor_id:
-                  type: string
-                  description: User ID of the new executor (must be a member of the team)
-              required:
-                - executor_id
+              $ref: '#/components/schemas/PatchedExecutorUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedExecutorUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedExecutorUpdateRequest'
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
       responses:
         '200':
           description: Executor updated successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
         '403':
           description: Forbidden - only SPOC can update executor for team task
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
         '404':
-          description: Task assignment not found or not a team assignment
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
+          description: Task assignment not found
         '500':
           description: Internal server error
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
     delete:
       operationId: delete_task_assignment
       description: Remove the assignment for a specific task
@@ -476,7 +451,7 @@ paths:
         name: teamId
         schema:
           type: string
-        description: 'If provided, filters tasks assigned to this team.'
+        description: If provided, filters tasks assigned to this team.
       tags:
       - tasks
       security:
@@ -664,71 +639,22 @@ paths:
   /v1/teams/{team_id}:
     get:
       operationId: get_team_by_id
-      description: 'Retrieve details for a specific team. If ?member=true is provided, the users array will include an addedOn field for each user, indicating when they were added to the team.'
-      summary: Get team details by ID
+      description: Retrieve a single team by its unique identifier. Optionally, set
+        ?member=true to get users belonging to this team.
+      summary: Get team by ID
       parameters:
-      - in: path
-        name: team_id
-        schema:
-          type: string
-        required: true
-        description: The ID of the team
       - in: query
         name: member
         schema:
           type: boolean
-        required: false
-        description: If true, include users array with addedOn field for each user
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  description:
-                    type: string
-                  created_by:
-                    type: string
-                  created_at:
-                    type: string
-                    format: date-time
-                  updated_at:
-                    type: string
-                    format: date-time
-                  users:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        email:
-                          type: string
-                        is_active:
-                          type: boolean
-                        is_verified:
-                          type: boolean
-                        created_at:
-                          type: string
-                          format: date-time
-                        updated_at:
-                          type: string
-                          format: date-time
-                        addedOn:
-                          type: string
-                          format: date-time
-                          description: Date the user was added to the team
-                        tasksAssignedCount:
-                          type: integer
-                          description: Number of tasks assigned to this user that are also assigned to this team
+        description: If true, returns users that belong to this team instead of team
+          details.
+      - in: path
+        name: team_id
+        schema:
+          type: string
+        description: Unique identifier of the team
+        required: true
       tags:
       - teams
       security:
@@ -744,7 +670,11 @@ paths:
           description: Internal server error
     patch:
       operationId: update_team
-      description: "Update a team's details including name, description, point of contact (POC), and team members. All fields are optional - only include the fields you want to update. For member management: if member_ids is provided, it completely replaces the current team members; if member_ids is not provided, existing members remain unchanged."
+      description: 'Update a team''s details including name, description, point of
+        contact (POC), and team members. All fields are optional - only include the
+        fields you want to update. For member management: if member_ids is provided,
+        it completely replaces the current team members; if member_ids is not provided,
+        existing members remain unchanged.'
       summary: Update team by ID
       parameters:
       - in: path
@@ -759,13 +689,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateTeamRequest'
+              $ref: '#/components/schemas/PatchedUpdateTeamRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/UpdateTeamRequest'
+              $ref: '#/components/schemas/PatchedUpdateTeamRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/UpdateTeamRequest'
+              $ref: '#/components/schemas/PatchedUpdateTeamRequest'
       security:
       - cookieAuth: []
       - basicAuth: []
@@ -778,40 +708,79 @@ paths:
                 $ref: '#/components/schemas/TeamDTO'
           description: Team updated successfully
         '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
           description: Bad request - validation error or invalid member IDs
         '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
           description: Team not found
         '500':
+          description: Internal server error
+  /v1/teams/{team_id}/members:
+    post:
+      operationId: add_team_members
+      description: Add new members to a team. Only existing team members can add other
+        members.
+      summary: Add members to a team
+      parameters:
+      - in: path
+        name: team_id
+        schema:
+          type: string
+        description: Unique identifier of the team
+        required: true
+      tags:
+      - teams
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddTeamMemberRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AddTeamMemberRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AddTeamMemberRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '#/components/schemas/TeamDTO'
+          description: Team members added successfully
+        '400':
+          description: Bad request - validation error or user not a team member
+        '404':
+          description: Team not found
+        '500':
           description: Internal server error
   /v1/teams/join-by-invite:
     post:
       operationId: join_team_by_invite_code
-      description: Join a team using a valid invite code. Returns the joined team details.
+      description: Join a team using a valid invite code. Returns the joined team
+        details.
       summary: Join a team by invite code
       tags:
-        - teams
+      - teams
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/JoinTeamByInviteCodeRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/JoinTeamByInviteCodeRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/JoinTeamByInviteCodeRequest'
         required: true
       security:
-        - cookieAuth: []
-        - basicAuth: []
-        - {}
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
       responses:
         '200':
           content:
@@ -820,65 +789,11 @@ paths:
                 $ref: '#/components/schemas/TeamDTO'
           description: Joined team successfully
         '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
           description: Bad request - validation error or already a member
         '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
           description: Team not found or invalid invite code
         '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
           description: Internal server error
-  /v1/teams/{teamid}/members:
-    post:
-      operationId: add_team_members
-      description: 'Add new members to a team. Only existing team members can add other members.'
-      summary: Add members to a team
-      parameters:
-      - in: path
-        name: teamid
-        schema:
-          type: string
-        required: true
-        description: The ID of the team
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                member_ids:
-                  type: array
-                  items:
-                    type: string
-                  minItems: 1
-                  description: List of user IDs to add to the team
-              required:
-              - member_ids
-      responses:
-        '200':
-          description: Team members added successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TeamDTO'
-        '400':
-          description: Bad request - validation error or user not a team member
-        '404':
-          description: Team not found
-        '500':
-          description: Internal server error
-      tags:
-      - teams
   /v1/users:
     get:
       operationId: get_users
@@ -1105,6 +1020,18 @@ paths:
           description: Unauthorized
 components:
   schemas:
+    AddTeamMemberRequest:
+      type: object
+      properties:
+        member_ids:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          description: List of user IDs to add to the team
+          minItems: 1
+      required:
+      - member_ids
     ApiErrorDetail:
       properties:
         source:
@@ -1291,25 +1218,6 @@ components:
           nullable: true
       required:
       - name
-    UpdateTeamRequest:
-      type: object
-      description: All fields are optional for PATCH operations. Only include the fields you want to update. For member management: if member_ids is provided, it completely replaces the current team members; if member_ids is not provided, existing members remain unchanged.
-      properties:
-        name:
-          type: string
-          minLength: 1
-          maxLength: 100
-        description:
-          type: string
-          maxLength: 500
-        member_ids:
-          type: array
-          items:
-            type: string
-            minLength: 1
-        poc_id:
-          type: string
-          nullable: true
     CreateTeamResponse:
       description: |-
         Response model for team creation endpoint.
@@ -1455,6 +1363,15 @@ components:
           type: array
       title: GetWatchlistTasksResponse
       type: object
+    JoinTeamByInviteCodeRequest:
+      type: object
+      properties:
+        invite_code:
+          type: string
+          minLength: 1
+          maxLength: 100
+      required:
+      - invite_code
     LabelDTO:
       properties:
         id:
@@ -1515,6 +1432,13 @@ components:
     NullEnum:
       enum:
       - null
+    PatchedExecutorUpdateRequest:
+      type: object
+      properties:
+        executor_id:
+          type: string
+          minLength: 1
+          description: User ID of the new executor (must be a member of the team)
     PatchedUpdateRoleRequest:
       type: object
       properties:
@@ -1568,6 +1492,29 @@ components:
           nullable: true
         isAcknowledged:
           type: boolean
+    PatchedUpdateTeamRequest:
+      type: object
+      description: |-
+        Serializer for updating team details.
+        All fields are optional for PATCH operations.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        description:
+          type: string
+          nullable: true
+          maxLength: 500
+        poc_id:
+          type: string
+          nullable: true
+          minLength: 1
+        member_ids:
+          type: array
+          items:
+            type: string
+            minLength: 1
     PatchedUpdateWatchlistRequest:
       type: object
       properties:
@@ -1812,8 +1759,7 @@ components:
           type: string
         users:
           anyOf:
-          - items:
-              $ref: '#/components/schemas/UserDTO'
+          - items: {}
             type: array
           - type: 'null'
           default: null
@@ -1836,6 +1782,19 @@ components:
         name:
           title: Name
           type: string
+        addedOn:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          default: null
+          title: Addedon
+        tasksAssignedCount:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          default: null
+          title: Tasksassignedcount
       required:
       - id
       - name
@@ -1973,16 +1932,6 @@ components:
       - watchlistId
       title: WatchlistDTO
       type: object
-    JoinTeamByInviteCodeRequest:
-      type: object
-      properties:
-        invite_code:
-          type: string
-          minLength: 1
-          maxLength: 100
-      required:
-        - invite_code
-      description: Request body for joining a team by invite code.
   securitySchemes:
     basicAuth:
       type: http

--- a/todo/models/audit_log.py
+++ b/todo/models/audit_log.py
@@ -4,6 +4,7 @@ from pydantic import Field
 from todo.models.common.document import Document
 from todo.models.common.pyobjectid import PyObjectId
 
+
 class AuditLogModel(Document):
     collection_name: ClassVar[str] = "audit_logs"
 
@@ -13,4 +14,4 @@ class AuditLogModel(Document):
     new_executor_id: PyObjectId
     spoc_id: PyObjectId
     action: str = "reassign_executor"
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc)) 
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/todo/models/audit_log.py
+++ b/todo/models/audit_log.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timezone
+from typing import ClassVar
+from pydantic import Field
+from todo.models.common.document import Document
+from todo.models.common.pyobjectid import PyObjectId
+
+class AuditLogModel(Document):
+    collection_name: ClassVar[str] = "audit_logs"
+
+    task_id: PyObjectId
+    team_id: PyObjectId
+    previous_executor_id: PyObjectId | None = None
+    new_executor_id: PyObjectId
+    spoc_id: PyObjectId
+    action: str = "reassign_executor"
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc)) 

--- a/todo/models/task_assignment.py
+++ b/todo/models/task_assignment.py
@@ -23,6 +23,7 @@ class TaskAssignmentModel(Document):
     updated_by: PyObjectId | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime | None = None
+    executor_id: PyObjectId | None = None  # User within the team who is executing the task
 
     @validator("task_id", "assignee_id", "created_by", "updated_by")
     def validate_object_ids(cls, v):

--- a/todo/repositories/audit_log_repository.py
+++ b/todo/repositories/audit_log_repository.py
@@ -2,6 +2,7 @@ from todo.models.audit_log import AuditLogModel
 from todo.repositories.common.mongo_repository import MongoRepository
 from datetime import datetime, timezone
 
+
 class AuditLogRepository(MongoRepository):
     collection_name = AuditLogModel.collection_name
 
@@ -12,4 +13,4 @@ class AuditLogRepository(MongoRepository):
         audit_log_dict = audit_log.model_dump(mode="json", by_alias=True, exclude_none=True)
         insert_result = collection.insert_one(audit_log_dict)
         audit_log.id = insert_result.inserted_id
-        return audit_log 
+        return audit_log

--- a/todo/repositories/audit_log_repository.py
+++ b/todo/repositories/audit_log_repository.py
@@ -1,0 +1,15 @@
+from todo.models.audit_log import AuditLogModel
+from todo.repositories.common.mongo_repository import MongoRepository
+from datetime import datetime, timezone
+
+class AuditLogRepository(MongoRepository):
+    collection_name = AuditLogModel.collection_name
+
+    @classmethod
+    def create(cls, audit_log: AuditLogModel) -> AuditLogModel:
+        collection = cls.get_collection()
+        audit_log.timestamp = datetime.now(timezone.utc)
+        audit_log_dict = audit_log.model_dump(mode="json", by_alias=True, exclude_none=True)
+        insert_result = collection.insert_one(audit_log_dict)
+        audit_log.id = insert_result.inserted_id
+        return audit_log 

--- a/todo/repositories/task_assignment_repository.py
+++ b/todo/repositories/task_assignment_repository.py
@@ -140,3 +140,36 @@ class TaskAssignmentRepository(MongoRepository):
             return result.modified_count > 0
         except Exception:
             return False
+
+    @classmethod
+    def update_executor(cls, task_id: str, executor_id: str, user_id: str) -> bool:
+        """
+        Update the executor_id for the active assignment of the given task_id.
+        """
+        collection = cls.get_collection()
+        try:
+            result = collection.update_one(
+                {"task_id": ObjectId(task_id), "is_active": True},
+                {
+                    "$set": {
+                        "executor_id": ObjectId(executor_id),
+                        "updated_by": ObjectId(user_id),
+                        "updated_at": datetime.now(timezone.utc),
+                    }
+                },
+            )
+            if result.modified_count == 0:
+                # Try with string if ObjectId doesn't work
+                result = collection.update_one(
+                    {"task_id": task_id, "is_active": True},
+                    {
+                        "$set": {
+                            "executor_id": ObjectId(executor_id),
+                            "updated_by": ObjectId(user_id),
+                            "updated_at": datetime.now(timezone.utc),
+                        }
+                    },
+                )
+            return result.modified_count > 0
+        except Exception:
+            return False

--- a/todo/repositories/team_repository.py
+++ b/todo/repositories/team_repository.py
@@ -79,6 +79,16 @@ class TeamRepository(MongoRepository):
         except Exception:
             return None
 
+    @classmethod
+    def is_user_spoc(cls, team_id: str, user_id: str) -> bool:
+        """
+        Check if the given user is the SPOC (poc_id) for the given team.
+        """
+        team = cls.get_by_id(team_id)
+        if not team or not team.poc_id:
+            return False
+        return str(team.poc_id) == str(user_id)
+
 
 class UserTeamDetailsRepository(MongoRepository):
     collection_name = UserTeamDetailsModel.collection_name

--- a/todo/services/task_service.py
+++ b/todo/services/task_service.py
@@ -67,8 +67,11 @@ class TaskService:
             # If team_id is provided, only allow SPOC to fetch tasks
             if team_id:
                 from todo.repositories.team_repository import TeamRepository
+
                 if not TeamRepository.is_user_spoc(team_id, user_id):
-                    return GetTasksResponse(tasks=[], links=None, error={"message": "Only SPOC can view team tasks.", "code": "FORBIDDEN"})
+                    return GetTasksResponse(
+                        tasks=[], links=None, error={"message": "Only SPOC can view team tasks.", "code": "FORBIDDEN"}
+                    )
 
             tasks = TaskRepository.list(page, limit, sort_by, order, user_id, team_id=team_id)
             total_count = TaskRepository.count(user_id, team_id=team_id)

--- a/todo/services/task_service.py
+++ b/todo/services/task_service.py
@@ -64,6 +64,12 @@ class TaskService:
         try:
             cls._validate_pagination_params(page, limit)
 
+            # If team_id is provided, only allow SPOC to fetch tasks
+            if team_id:
+                from todo.repositories.team_repository import TeamRepository
+                if not TeamRepository.is_user_spoc(team_id, user_id):
+                    return GetTasksResponse(tasks=[], links=None, error={"message": "Only SPOC can view team tasks.", "code": "FORBIDDEN"})
+
             tasks = TaskRepository.list(page, limit, sort_by, order, user_id, team_id=team_id)
             total_count = TaskRepository.count(user_id, team_id=team_id)
 

--- a/todo/views/task_assignment.py
+++ b/todo/views/task_assignment.py
@@ -146,6 +146,73 @@ class TaskAssignmentDetailView(APIView):
             )
 
     @extend_schema(
+        operation_id="set_executor_for_team_task",
+        summary="Set or update executor for a team-assigned task (SPOC only)",
+        description="Allows the SPOC of a team to set or update the executor (user within the team) for a team-assigned task.",
+        tags=["task-assignments"],
+        request=None,  # Accepts JSON body with executor_id
+        parameters=[
+            OpenApiParameter(
+                name="task_id",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="Unique identifier of the task",
+                required=True,
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(description="Executor updated successfully"),
+            403: OpenApiResponse(description="Forbidden - only SPOC can update executor for team task"),
+            404: OpenApiResponse(response=ApiErrorResponse, description="Task assignment not found"),
+            500: OpenApiResponse(response=ApiErrorResponse, description="Internal server error"),
+        },
+    )
+    def patch(self, request: Request, task_id: str):
+        """
+        Set or update the executor for a team-assigned task. Only the SPOC can perform this action.
+        """
+        user = get_current_user_info(request)
+        if not user:
+            raise AuthenticationFailed(ApiErrors.AUTHENTICATION_FAILED)
+
+        executor_id = request.data.get("executor_id")
+        if not executor_id:
+            return Response({"error": "executor_id is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Fetch the assignment and check if it's a team assignment
+        from todo.repositories.task_assignment_repository import TaskAssignmentRepository
+        from todo.repositories.team_repository import TeamRepository
+        assignment = TaskAssignmentRepository.get_by_task_id(task_id)
+        if not assignment or assignment.user_type != "team":
+            return Response({"error": "Task is not assigned to a team or does not exist."}, status=status.HTTP_404_NOT_FOUND)
+
+        # Only SPOC can update executor
+        if not TeamRepository.is_user_spoc(str(assignment.assignee_id), user["user_id"]):
+            return Response({"error": "Only the SPOC can update executor for this team task."}, status=status.HTTP_403_FORBIDDEN)
+
+        # Update executor_id
+        from todo.repositories.task_assignment_repository import TaskAssignmentRepository
+        updated = TaskAssignmentRepository.update_executor(task_id, executor_id, user["user_id"])
+        if not updated:
+            return Response({"error": "Failed to update executor."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        # Audit log
+        from todo.models.audit_log import AuditLogModel
+        from todo.repositories.audit_log_repository import AuditLogRepository
+        previous_executor_id = assignment.executor_id if hasattr(assignment, 'executor_id') else None
+        audit_log = AuditLogModel(
+            task_id=assignment.task_id,
+            team_id=assignment.assignee_id,
+            previous_executor_id=previous_executor_id,
+            new_executor_id=executor_id,
+            spoc_id=user["user_id"],
+            action="reassign_executor"
+        )
+        AuditLogRepository.create(audit_log)
+
+        return Response({"message": "Executor updated successfully."}, status=status.HTTP_200_OK)
+
+    @extend_schema(
         operation_id="delete_task_assignment",
         summary="Delete task assignment",
         description="Remove the assignment for a specific task",


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add an endpoint to set or update the executor for team-assigned tasks, allowing only the Single Point of Contact (SPOC) to perform this action, and implement audit logging for re-assignments.

### Why are these changes being made?
This change enables more flexible and controlled task management within teams by allowing the team SPOC to assign or change the executor of tasks as necessary, improving task accountability and oversight. The decision to log all SPOC re-assignments ensures traceability and accountability, enhancing transparency within the task management process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->