### PR TITLE
fix: add debug logging for missing label IDs in TaskService

### DIFF
--- a/todo/services/task_service.py
+++ b/todo/services/task_service.py
@@ -170,7 +170,9 @@ class TaskService:
         found_ids = {str(label_model.id) for label_model in label_models}
         missing_ids = [label_id for label_id in label_ids if label_id not in found_ids]
         if missing_ids:
-            print(f"[DEBUG] The following label IDs are referenced by tasks but do not exist in the database: {missing_ids}")
+            print(
+                f"[DEBUG] The following label IDs are referenced by tasks but do not exist in the database: {missing_ids}"
+            )
         return [
             LabelDTO(
                 id=str(label_model.id),


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add debug logging to identify missing label IDs in the `_prepare_label_dtos` method of the `TaskService`.

### Why are these changes being made?

This change helps developers and maintainers identify label IDs referenced by tasks that do not exist in the database, which is crucial for debugging issues related to task-label associations. This is a straightforward approach to enhance visibility during debugging without affecting existing functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->