### PR TITLE
feat: add utility function to convert ObjectId to string in Watchlist…

### DIFF
--- a/todo/repositories/watchlist_repository.py
+++ b/todo/repositories/watchlist_repository.py
@@ -19,6 +19,7 @@ def _convert_objectids_to_str(obj):
     else:
         return obj
 
+
 class WatchlistRepository(MongoRepository):
     collection_name = WatchlistModel.collection_name
 
@@ -89,7 +90,6 @@ class WatchlistRepository(MongoRepository):
         result = next(aggregation_result, {"total": 0, "data": []})
         count = result.get("total", 0)
 
-       
         tasks = [_convert_objectids_to_str(doc) for doc in result.get("data", [])]
         tasks = [WatchlistDTO(**doc) for doc in tasks]
 

--- a/todo/repositories/watchlist_repository.py
+++ b/todo/repositories/watchlist_repository.py
@@ -8,6 +8,17 @@ from todo.dto.watchlist_dto import WatchlistDTO
 from bson import ObjectId
 
 
+def _convert_objectids_to_str(obj):
+    """Recursively convert all ObjectId values in a dict/list to strings."""
+    if isinstance(obj, dict):
+        return {k: _convert_objectids_to_str(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_convert_objectids_to_str(item) for item in obj]
+    elif isinstance(obj, ObjectId):
+        return str(obj)
+    else:
+        return obj
+
 class WatchlistRepository(MongoRepository):
     collection_name = WatchlistModel.collection_name
 
@@ -78,7 +89,9 @@ class WatchlistRepository(MongoRepository):
         result = next(aggregation_result, {"total": 0, "data": []})
         count = result.get("total", 0)
 
-        tasks = [WatchlistDTO(**doc) for doc in result.get("data", [])]
+       
+        tasks = [_convert_objectids_to_str(doc) for doc in result.get("data", [])]
+        tasks = [WatchlistDTO(**doc) for doc in tasks]
 
         return count, tasks
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a utility function `_convert_objectids_to_str` to convert all `ObjectId` instances within dictionaries or lists to string representations in the `WatchlistRepository`.

### Why are these changes being made?
The change ensures that `ObjectId` values are converted to strings when processing watchlisted tasks, as these values need to be serialized for output or data transfer. This approach helps maintain consistency in data representation and avoids potential issues with object serialization or display.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->