### PR TITLE
fix: return priority as enum string in watchlist API

### DIFF
--- a/todo/dto/watchlist_dto.py
+++ b/todo/dto/watchlist_dto.py
@@ -2,14 +2,16 @@ from datetime import datetime
 from pydantic import BaseModel
 from typing import Optional
 
+from todo.constants.task import TaskPriority, TaskStatus
+
 
 class WatchlistDTO(BaseModel):
     taskId: str
     displayId: str
     title: str
     description: Optional[str] = None
-    priority: Optional[int] = None
-    status: Optional[str] = None
+    priority: Optional[TaskPriority] = None
+    status: Optional[TaskStatus] = None
     isAcknowledged: Optional[bool] = None
     isDeleted: Optional[bool] = None
     labels: list = []
@@ -17,6 +19,9 @@ class WatchlistDTO(BaseModel):
     createdAt: datetime
     createdBy: str
     watchlistId: str
+
+    class Config:
+        json_encoders = {TaskPriority: lambda x: x.name}
 
 
 class CreateWatchlistDTO(BaseModel):


### PR DESCRIPTION

<!-- Date Here in dd mmm yyyy-->
Date: `July 19, 2025`
<!--Developer Name Here-->
Developer Name: @Achintya-Chatterjee 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->

## Description
<!--Description of the changes made in this PR-->
Align the watchlist API response format with the tasks API by converting TaskPriority enum values from integers to string names.

- Update WatchlistDTO to use TaskPriority/TaskStatus enums
- Add json_encoders config for consistent serialization
- Maintain API consistency across all task-related endpoints

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>
<!-- Attach your screenshots here👇-->
<img width="1063" height="818" alt="Screenshot 2025-07-19 at 01 33 49" src="https://github.com/user-attachments/assets/29bf4348-3b6d-43a8-aa59-f34dd294f7e7" />

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Modify the WatchlistDTO to return the priority as an enum string rather than an integer in the Watchlist API.

### Why are these changes being made?
The change ensures that the priority field in the WatchlistDTO is more human-readable by using the enum name instead of its integer representation, improving data clarity and consistency with the rest of the API data structures. This approach leverages Pydantic's `json_encoders` to automatically convert `TaskPriority` enum to its string representation, enhancing maintainability and reducing potential errors in interpreting task priority values.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->