### PR TITLE
feat: implement update_task_with_assignee_from_dict method for partia…

### DIFF
--- a/todo/views/task.py
+++ b/todo/views/task.py
@@ -314,7 +314,7 @@ class TaskUpdateView(APIView):
                 required=True,
             ),
         ],
-        request=CreateTaskSerializer,
+        request=UpdateTaskSerializer,
         responses={
             200: OpenApiResponse(description="Task and assignee updated successfully"),
             400: OpenApiResponse(description="Bad request"),
@@ -331,17 +331,16 @@ class TaskUpdateView(APIView):
         if not user:
             raise AuthenticationFailed(ApiErrors.AUTHENTICATION_FAILED)
 
-        serializer = CreateTaskSerializer(data=request.data, partial=True)
+        serializer = UpdateTaskSerializer(data=request.data, partial=True)
 
         if not serializer.is_valid():
             return self._handle_validation_errors(serializer.errors)
 
         try:
-            # Create DTO with the validated data
-            dto = CreateTaskDTO(**serializer.validated_data, createdBy=user["user_id"])
-
-            # Update the task using the service
-            updated_task_dto = TaskService.update_task_with_assignee(task_id=task_id, dto=dto, user_id=user["user_id"])
+            # Update the task using the service with validated data
+            updated_task_dto = TaskService.update_task_with_assignee_from_dict(
+                task_id=task_id, validated_data=serializer.validated_data, user_id=user["user_id"]
+            )
 
             return Response(data=updated_task_dto.model_dump(mode="json"), status=status.HTTP_200_OK)
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement the `update_task_with_assignee_from_dict` method in the `TaskService` class to allow partial updates to tasks, including updating the task details and assignee simultaneously using a validated data dictionary, and update associated tests and views to accommodate this new method.

### Why are these changes being made?

These changes improve flexibility in updating tasks by not requiring all fields to be present when updating, allowing for more granular changes. This approach accommodates scenarios where only specific fields might need updating, such as just the assignment details without altering other attributes of a task, thereby enhancing efficiency and ease of maintenance in handling task updates in the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->