### PR TITLE
feat: add team invite code retrieval endpoint

### DIFF
--- a/todo/urls.py
+++ b/todo/urls.py
@@ -5,7 +5,7 @@ from todo.views.user import UsersView
 from todo.views.auth import GoogleLoginView, GoogleCallbackView, LogoutView
 from todo.views.role import RoleListView, RoleDetailView
 from todo.views.label import LabelListView
-from todo.views.team import TeamListView, TeamDetailView, JoinTeamByInviteCodeView, AddTeamMembersView
+from todo.views.team import TeamListView, TeamDetailView, JoinTeamByInviteCodeView, AddTeamMembersView, TeamInviteCodeView
 from todo.views.watchlist import WatchlistListView, WatchlistDetailView, WatchlistCheckView
 from todo.views.task_assignment import TaskAssignmentView, TaskAssignmentDetailView
 from todo.views.task import AssignTaskToUserView
@@ -15,6 +15,7 @@ urlpatterns = [
     path("teams/join-by-invite", JoinTeamByInviteCodeView.as_view(), name="join_team_by_invite"),
     path("teams/<str:team_id>", TeamDetailView.as_view(), name="team_detail"),
     path("teams/<str:team_id>/members", AddTeamMembersView.as_view(), name="add_team_members"),
+    path("teams/<str:team_id>/invite-code", TeamInviteCodeView.as_view(), name="team_invite_code"),
     path("tasks", TaskListView.as_view(), name="tasks"),
     path("tasks/<str:task_id>", TaskDetailView.as_view(), name="task_detail"),
     path("tasks/<str:task_id>/update", TaskUpdateView.as_view(), name="update_task_and_assignee"),

--- a/todo/urls.py
+++ b/todo/urls.py
@@ -5,7 +5,13 @@ from todo.views.user import UsersView
 from todo.views.auth import GoogleLoginView, GoogleCallbackView, LogoutView
 from todo.views.role import RoleListView, RoleDetailView
 from todo.views.label import LabelListView
-from todo.views.team import TeamListView, TeamDetailView, JoinTeamByInviteCodeView, AddTeamMembersView, TeamInviteCodeView
+from todo.views.team import (
+    TeamListView,
+    TeamDetailView,
+    JoinTeamByInviteCodeView,
+    AddTeamMembersView,
+    TeamInviteCodeView,
+)
 from todo.views.watchlist import WatchlistListView, WatchlistDetailView, WatchlistCheckView
 from todo.views.task_assignment import TaskAssignmentView, TaskAssignmentDetailView
 from todo.views.task import AssignTaskToUserView

--- a/todo/views/team.py
+++ b/todo/views/team.py
@@ -363,4 +363,7 @@ class TeamInviteCodeView(APIView):
         is_poc = str(team.poc_id) == str(user_id)
         if is_creator or is_poc:
             return Response({"invite_code": team.invite_code}, status=status.HTTP_200_OK)
-        return Response({"detail": "You are not authorized to view the invite code for this team."}, status=status.HTTP_403_FORBIDDEN)
+        return Response(
+            {"detail": "You are not authorized to view the invite code for this team."},
+            status=status.HTTP_403_FORBIDDEN,
+        )


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a new API endpoint for retrieving a team's invite code, accessible only by the team's creator or Point-Of-Contact (POC).

### Why are these changes being made?
This change addresses the need for team creators or POCs to securely retrieve their team's unique invite code, thereby enhancing the team's access management capabilities. The decision to restrict this access to only specific roles ensures enhanced security and data privacy within the team collaborations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->