### PR TITLE
feat: add method to retrieve multiple tasks by their IDs in a single …

### DIFF
--- a/todo/repositories/task_repository.py
+++ b/todo/repositories/task_repository.py
@@ -214,3 +214,16 @@ class TaskRepository(MongoRepository):
         query = {"_id": {"$in": assigned_task_ids}}
         tasks_cursor = tasks_collection.find(query).skip((page - 1) * limit).limit(limit)
         return [TaskModel(**task) for task in tasks_cursor]
+
+    @classmethod
+    def get_by_ids(cls, task_ids: List[str]) -> List[TaskModel]:
+        """
+        Get multiple tasks by their IDs in a single database query.
+        Returns only the tasks that exist.
+        """
+        if not task_ids:
+            return []
+        tasks_collection = cls.get_collection()
+        object_ids = [ObjectId(task_id) for task_id in task_ids]
+        cursor = tasks_collection.find({"_id": {"$in": object_ids}})
+        return [TaskModel(**doc) for doc in cursor]


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a method to the `TaskRepository` class to retrieve multiple tasks by their IDs in a single database query.

### Why are these changes being made?

This change addresses the need for efficiently fetching multiple tasks by their identifier, reducing the amount of database queries and improving performance when such a retrieval is needed. The method returns only tasks that exist, handling cases where some IDs might not correspond to any task.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->