### PR TITLE
refactor: remove invite_code handling from team creation response

### DIFF
--- a/todo/views/team.py
+++ b/todo/views/team.py
@@ -77,9 +77,6 @@ class TeamListView(APIView):
             created_by_user_id = request.user_id
             response: CreateTeamResponse = TeamService.create_team(dto, created_by_user_id)
             data = response.model_dump(mode="json")
-            # Remove invite_code from the created team
-            if "team" in data:
-                data["team"].pop("invite_code", None)
             return Response(data=data, status=status.HTTP_201_CREATED)
 
         except ValueError as e:


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 23 July 2025
<!--Developer Name Here-->
Developer Name: @AnujChhikara 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Invite code missing in response when we have created the task
## Description

<!--Description of the changes made in this PR-->
- Earlier we pop the invite code when we are sending the response for the create team which break the workflow as it is needed to send invite code after we created the team
- with these changes we are sending the invite code only when we create the team 
### Documentation Updated?

- [ ] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

https://github.com/user-attachments/assets/f40b5ff0-0f35-4742-bede-00eeaeaa06c8


</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
