### PR TITLE
fix(valid-due-date): update serializer to compare only dates in IST timezone

### DIFF
--- a/todo/serializers/create_task_serializer.py
+++ b/todo/serializers/create_task_serializer.py
@@ -1,8 +1,9 @@
 from rest_framework import serializers
 from bson import ObjectId
-from datetime import datetime, timezone
+from datetime import datetime
 from todo.constants.task import TaskPriority, TaskStatus
 from todo.constants.messages import ValidationErrors
+from zoneinfo import ZoneInfo
 
 
 class CreateTaskSerializer(serializers.Serializer):
@@ -52,8 +53,10 @@ class CreateTaskSerializer(serializers.Serializer):
 
     def validate_dueAt(self, value):
         if value is not None:
-            now = datetime.now(timezone.utc)
-            if value <= now:
+            ist_timezone = ZoneInfo("Asia/Kolkata")
+            now_date = datetime.now(ist_timezone).date()
+            value_date = value.astimezone(ist_timezone).date()
+            if value_date < now_date:
                 raise serializers.ValidationError(ValidationErrors.PAST_DUE_DATE)
         return value
 

--- a/todo/serializers/update_task_serializer.py
+++ b/todo/serializers/update_task_serializer.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 from todo.constants.task import TaskPriority, TaskStatus
 from todo.constants.messages import ValidationErrors
+from zoneinfo import ZoneInfo
 
 
 class UpdateTaskSerializer(serializers.Serializer):
@@ -50,11 +51,13 @@ class UpdateTaskSerializer(serializers.Serializer):
         return value
 
     def validate_dueAt(self, value):
+        ist_timezone = ZoneInfo("Asia/Kolkata")
         if value is None:
             return value
         errors = []
-        now = datetime.now(timezone.utc)
-        if value <= now:
+        now_date = datetime.now(ist_timezone).date()
+        value_date = value.astimezone(ist_timezone).date()
+        if value_date < now_date:
             errors.append(ValidationErrors.PAST_DUE_DATE)
         if errors:
             raise serializers.ValidationError(errors)


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date:  03 Aug 2025
<!--Developer Name Here-->
Developer Name: @Hariom01010 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
Closes #239 
## Description

<!--Description of the changes made in this PR-->
This PR updates the due date validation logic in the create_task_serializer and update_task_serializer:
- Compares only the date component (ignoring time) instead of the full datetime.
- Converts both the input value and current time to IST timezone to ensure consistent and accurate date-based validation.
Now validation only fails if the current date is less than the due date sent by the user.
### Documentation Updated?

- [ ] Yes
- [X] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [X] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [X] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [X] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [X] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

https://github.com/user-attachments/assets/5749ce24-e05d-4352-8288-0203efad4bbb


</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
<img width="1078" height="441" alt="image" src="https://github.com/user-attachments/assets/777ccbba-bb87-4f5b-a6b4-910bc660928f" />

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
