### PR TITLE
fix: correct syntax for setting PYTHONUNBUFFERED environment variable in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.12-slim-bookworm
 
 # Set environment variables
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 
<!--Developer Name Here-->
Developer Name: 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->

## Description

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the syntax for setting the `PYTHONUNBUFFERED` environment variable in the Dockerfile by adding an equal sign.

### Why are these changes being made?

The prior syntax omitted an equal sign, which is required for correctly setting environment variables in a Dockerfile. This change ensures that the `PYTHONUNBUFFERED` setting is properly applied, preventing potential issues with Python's output buffering in Docker containers.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->